### PR TITLE
Develop with update request fix

### DIFF
--- a/base_content.sol
+++ b/base_content.sol
@@ -19,6 +19,7 @@ BaseContent20190605203200ML: Splits publish and confirm logic
 BaseContent20190724203300ML: Enforces access rights in access request
 BaseContent20190801141600ML: Fixes the access rights grant for paid content
 BaseContent20191029161700ML: Removed debug statements for accessRequest
+BaseContent20191219135200ML: Made content object updatable by non-owner
 */
 
 
@@ -391,6 +392,22 @@ contract BaseContent is Editable {
         bool enough
     );
     event DbgAccessCode(uint8 code);
+
+    function updateRequest() public {
+        if (contentContractAddress == 0x0) {
+            super.updateRequest();
+        } else {
+            Content c = Content(contentContractAddress);
+            uint editCode = c.runEdit();
+            if (editCode == 100) {
+                super.updateRequest();
+            } else {
+                require(editCode == 0);
+                emit UpdateRequest(objectHash);
+            }
+        }
+    }
+
 
     //  level - the security group for which the access request is for
     //  pkeRequestor - ethereum public key of the requestor (ECIES)

--- a/base_content_space.sol
+++ b/base_content_space.sol
@@ -214,7 +214,7 @@ contract BaseContentSpace is MetaObject, Accessible, Container, UserSpace, NodeS
     function getKMSID(address _kmsAddr) public view returns (string){
         return Precompile.makeIDString(Precompile.CodeKMS(), _kmsAddr);
     }
-    
+
     function checkKMS(string _kmsIdStr) public view returns (uint) {
         return kmsMapping[_kmsIdStr].length;
     }
@@ -282,7 +282,7 @@ contract BaseContentSpace is MetaObject, Accessible, Container, UserSpace, NodeS
     // status -> 1 not added
     function addKMSLocator(string _kmsID, bytes _locator) public onlyOwner returns (bool) {
         bytes[] memory kmsLocators = kmsMapping[_kmsID];
-        
+
         for (uint i = 0; i < kmsLocators.length; i++) {
             if (keccak256(kmsLocators[i]) == keccak256(_locator)) {
                 emit AddKMSLocator(msg.sender, 1);
@@ -408,11 +408,12 @@ contract BaseLibraryFactory is Ownable {
 /* -- Revision history --
 BaseCtFactory20190509171900ML: Split out of BaseLibraryFactory
 BaseCtFactory20191017165200ML: Updated to reflect change in BaseContent20190801141600ML
+BaseCtFactory20191219182100ML: Updated to reflect change in BaseContent20191219135200ML
 */
 
 contract BaseContentFactory is Ownable {
 
-    bytes32 public version ="BaseCtFactory20191202165200ML"; //class name (max 16), date YYYYMMDD, time HHMMSS and Developer initials XX
+    bytes32 public version ="BaseCtFactory20191219182100ML"; //class name (max 16), date YYYYMMDD, time HHMMSS and Developer initials XX
 
     function createContent(address lib, address content_type) public  returns (address) {
         Container libraryObj = Container(lib);

--- a/content.sol
+++ b/content.sol
@@ -10,11 +10,12 @@ Content20190315171500ML: Migrated to 0.4.24
 Content20190506155000ML: Makes the default for runAccess match content object behavior that does not have custom contract
 Content20190510151600ML: Modified API for runAccessInfo to add Access information
 Content20191031162000ML: Adds finalize method for state channel
+Content20191219134300ML: Adds hook to be used to override standard behavior for authorization to edit
 */
 
 contract Content is Ownable {
 
-    bytes32 public version ="Content20191031162000ML"; //class name (max 16), date YYYYMMDD, time HHMMSS and Developer initials XX
+    bytes32 public version ="Content20191219134300ML"; //class name (max 16), date YYYYMMDD, time HHMMSS and Developer initials XX
 
     uint8 public constant DEFAULT_SEE  = 1;
     uint8 public constant DEFAULT_ACCESS  = 2;
@@ -43,6 +44,13 @@ contract Content is Ownable {
     function runCreate() public payable returns (uint) {
         return 0;
     }
+
+
+   //0 indicates edit can proceed
+   //100 indicates that custom contract does not modify default behavior
+   function runEdit() public returns (uint) {
+       return 100;
+   }
 
     //0 indicates that the deletion/inactivation can proceed.
     //100 indicates that the deletion can proceed and the custom contract should be killed too

--- a/editable.sol
+++ b/editable.sol
@@ -11,13 +11,14 @@ Editable20190522154000SS: Changed hash bytes32 to string
 Editable20190605144500ML: Renamed publish to confirm to avoid confusion in the case of the content-objects
 Editable20190715105600PO
 Editable20190801135500ML: Made explicit the definition of parentAddress method
+Editable20191219134600ML: Made updateRequest contingent on canEdit rather than ownership
 */
 
 
 contract Editable is Ownable {
     using strings for *;
 
-    bytes32 public version ="Editable20190801135500ML"; //class name (max 16), date YYYYMMDD, time HHMMSS and Developer initials XX
+    bytes32 public version ="Editable20191219134600ML"; //class name (max 16), date YYYYMMDD, time HHMMSS and Developer initials XX
 
     event CommitPending(address spaceAddress, address parentAddress, string objectHash);
     event UpdateRequest(string objectHash);
@@ -52,6 +53,11 @@ contract Editable is Ownable {
 
     function countVersionHashes() public view returns (uint256) {
         return versionHashes.length;
+    }
+
+    //This function is meant to be overloaded. By default the owner is the only editor
+    function canEdit() public view returns (bool) {
+        return (tx.origin == owner);
     }
 
     // intended to be overridden
@@ -100,13 +106,13 @@ contract Editable is Ownable {
     }
 
     function updateRequest() public {
-        require(msg.sender == owner || canConfirm());
+        require(canEdit() || canConfirm());
         emit UpdateRequest(objectHash);
     }
 
     function deleteVersion(string _versionHash) public returns (int256) {
         require(canCommit());
-        
+
         bytes32 findHash = keccak256(abi.encodePacked(_versionHash));
         bytes32 objHash = keccak256(abi.encodePacked(objectHash));
         if (findHash == objHash) {
@@ -115,7 +121,7 @@ contract Editable is Ownable {
             emit VersionDelete(contentSpace, _versionHash, 0);
             return 0;
         }
-        
+
         int256 foundIdx = -1;
         for (uint256 i = 0; i < versionHashes.length; i++) {
             bytes32 checkHash = keccak256(abi.encodePacked(versionHashes[i]));

--- a/editable.sol
+++ b/editable.sol
@@ -57,7 +57,7 @@ contract Editable is Ownable {
 
     //This function is meant to be overloaded. By default the owner is the only editor
     function canEdit() public view returns (bool) {
-        return (tx.origin == owner);
+        return (msg.sender == owner);
     }
 
     // intended to be overridden

--- a/sample_screener.sol
+++ b/sample_screener.sol
@@ -1,0 +1,151 @@
+pragma solidity 0.4.24;
+
+import {Content} from "./content.sol";
+import {BaseContent} from "./base_content.sol";
+import {BaseContentSpace} from "./base_content_space.sol";
+import {BaseAccessControlGroup} from "./base_access_control_group.sol";
+import {AccessIndexor} from "./access_indexor.sol";
+
+
+/* -- Revision history --
+SmplScreener20191202201500ML: First versioned released
+SmplScreener20191204144100ML: Fixes the logic of access to check first for direct access and allows non editor access
+*/
+
+contract SampleScreener is Content {
+
+    bytes32 public version ="SmplScreener20191204144100ML"; //class name (max 16), date YYYYMMDD, time HHMMSS and Developer initials XX
+
+    event SetAvailability(address content, uint256 start, uint256 end, uint8 status);
+
+    struct Avail {
+        uint256 start; //0 indicates no limit
+        uint256 end; //0 indicates no limit
+        uint8 status; //0 indicates disabled
+    }
+    mapping(address => Avail) public availability;
+
+    address public screeners; //screener group
+
+    address public screenerManager;
+
+    address[] public assets;
+    uint256 public assetsLength = 0;
+
+    function setScreeners(address group) public onlyOwner {
+        screeners = group;
+    }
+
+    function setAvailability(address content, uint256 start, uint256 end) public onlyOwner {
+        //Could be changed to only allow content owner instead of screener contract owner to set availability
+        availability[content].start = start;
+        availability[content].end = end;
+        availability[content].status = 1;
+        emit SetAvailability(content, start, end, 1);
+    }
+
+    function makeUnavailable(address content) public onlyOwner {
+         availability[content].status = 0;
+        emit SetAvailability(content, availability[content].start, availability[content].end, 0);
+    }
+
+    function makeAvailable(address content) public onlyOwner {
+        availability[content].status = 1;
+        emit SetAvailability(content, availability[content].start, availability[content].end, 1);
+    }
+
+    function runCreate() public payable returns (uint) {
+        if (screenerManager == 0x0) {
+            screenerManager = msg.sender;
+        } else {
+            availability[msg.sender] = Avail(0, 0, 0);
+            assets.push(msg.sender);
+            assetsLength = assetsLength+1;
+        }
+        return 0;
+    }
+
+
+    function runKill() public payable returns (uint) {
+        delete availability[msg.sender];
+        return 0;
+    }
+
+
+    function runAccessInfo( //Old API
+        uint8, /*level*/
+        bytes32[], /*customValues*/
+        address[] /*stakeholders*/
+    )
+    public view returns (uint8, uint8, uint8, uint256) //Mask, visibilityCode, accessCode, accessCharge
+    {
+        BaseContent content  = BaseContent(msg.sender);
+        //First check if user has been granted explicit right to the object
+        address walletAddress =  BaseContentSpace(content.contentSpace()).userWallets(tx.origin);
+        AccessIndexor wallet = AccessIndexor(walletAddress);
+        if (wallet.checkContentObjectRights(msg.sender, wallet.TYPE_ACCESS())) {
+            return (0, 0, 0 ,0); // Object is accessible
+        }
+
+        BaseAccessControlGroup group = BaseAccessControlGroup(screeners);
+        if (group.hasAccessRight(tx.origin, false)) {
+            if ((availability[msg.sender].status != 0) && (availability[msg.sender].start <= now) && ((availability[msg.sender].end == 0) || (availability[msg.sender].end >= now))) {
+                return (0, 0, 0 ,0); // no charges
+            } else {
+                return (0, 2, 2, 0); //outside of availability
+            }
+        }
+        return (0, 1, 1, 0); //Bar access to unauthorized user
+    }
+
+    /*  // not needed for now, might be required if special reporting is added
+    //0 indicates that access request can proceed.
+    // Other numbers can be used as error codes and would stop the processing.
+    function runAccess(
+        uint256 request_ID,
+        uint8 level,
+        bytes32[] custom_values,
+        address[] stake_holders
+    )
+    public payable returns(uint)
+    {
+        return 0;
+    }
+    */
+
+
+    /*
+    function runAccessInfo( //new API
+        address accessor,
+        uint8 level,
+        bytes32[] customValues,
+        address[] stakeholders
+    )
+    public view returns (uint256[4]) //Mask, visibilityCode, accessCode, accessCharge
+    {
+        return [uint256(7), 0, 0, 0]; //7 is DEFAULT_SEE + DEFAULT_ACCESS + DEFAULT_CHARGE, hence the 3 tailing values are ignored
+    }
+    */
+
+
+    /*
+    //0 indicates that access request can proceed.
+    // Other numbers can be used as error codes and would stop the processing.
+    function runAccess( //new API
+        bytes32 requestNonce,
+        address accessor,
+        uint8 level,
+        uint256 value,
+        bytes32[] custom_values,
+        address[] stake_holders
+    )
+    public payable returns(uint)
+    {
+        return 0;
+    }
+    */
+
+
+
+
+}


### PR DESCRIPTION
2 changes in there:

1/ made updateRequest accessible to anyone that is canEdit positive
2/ adds a custom contract hook to overload the updateRequest logic (we needed that for example to prevent a recording owner from editing a recording)