### PR TITLE
Enforces visibility driven rights to edit

### DIFF
--- a/base_content.sol
+++ b/base_content.sol
@@ -20,12 +20,13 @@ BaseContent20190724203300ML: Enforces access rights in access request
 BaseContent20190801141600ML: Fixes the access rights grant for paid content
 BaseContent20191029161700ML: Removed debug statements for accessRequest
 BaseContent20191219135200ML: Made content object updatable by non-owner
+BaseContent20200102165900ML: Enforce visibility driven rights to edit
 */
 
 
 contract BaseContent is Editable {
 
-    bytes32 public version ="BaseContent20191202161700ML"; //class name (max 16), date YYYYMMDD, time HHMMSS and Developer initials XX
+    bytes32 public version ="BaseContent20200102165900ML"; //class name (max 16), date YYYYMMDD, time HHMMSS and Developer initials XX
 
     address public contentType;
     address public addressKMS;
@@ -318,6 +319,9 @@ contract BaseContent is Editable {
     }
 
     function canEdit() public view returns (bool) {
+        if (visibility >= 100) {
+         return true;
+        }
         IUserSpace userSpaceObj = IUserSpace(contentSpace);
         address walletAddress = userSpaceObj.userWallets(tx.origin);
         AccessIndexor wallet = AccessIndexor(walletAddress);


### PR DESCRIPTION
If visibility is set to 100 to allow anybody the right to edit an object, the current code did not abide and edit is restricted using the other criteria (ownership, group granted rights or user granted rights). 
This is unusual, but could be used legitimately for a wiki-type object.