### PR TITLE
Disambiguate set rights

### DIFF
--- a/access_indexor.sol
+++ b/access_indexor.sol
@@ -14,12 +14,13 @@ AccessIndexor20191113202400ML: Ensures accessor has at least access right to a g
 AccessIndexor20200110100200ML: Removes debug events
 AccessIndexor20200204144400ML: Fixes lookup of group based rights to check group membership vs. visibility only
 AccessIndexor20200316121400ML: replaces entity-specific set and check rights with generic one that uses index-type
+AccessIndexor20200410215200ML: disambiguate setRights by renaming setEntityRights
 */
 
 
 contract AccessIndexor is Ownable {
 
-    bytes32 public version = "AccessIndexor20200316121400ML";
+    bytes32 public version = "AccessIndexor20200410215200ML";
 
     event RightsChanged(address principal, address entity, uint8 aggregate);
 
@@ -259,7 +260,7 @@ contract AccessIndexor is Ownable {
     }
 
 
-    function setRights(uint8 indexType, address obj, uint8 access_type, uint8 access) public  {
+    function setEntityRights(uint8 indexType, address obj, uint8 access_type, uint8 access) public  {
         if (indexType != 0) {
             setRightsInternal(getAccessIndex(indexType),  obj,  access_type,  access);
         }

--- a/editable.sol
+++ b/editable.sol
@@ -19,14 +19,14 @@ Editable20200109145900ML: Limited updateRequest to canEdit
 Editable20200124080600ML: Fixed deletion of latest version
 Editable20200210163900ML: Modified for authV3 support
 Editable20200316135400ML: Implements check and set rights to be inherited from
-
+Editable20200410215400ML: disambiguate indexor.setRights and entity.setRights 
 */
 
 
 contract Editable is  Accessible {
     using strings for *;
 
-    bytes32 public version ="Editable20200316135400ML"; //class name (max 16), date YYYYMMDD, time HHMMSS and Developer initials XX
+    bytes32 public version ="Editable20200410215400ML"; //class name (max 16), date YYYYMMDD, time HHMMSS and Developer initials XX
 
     event CommitPending(address spaceAddress, address parentAddress, string objectHash);
     event UpdateRequest(string objectHash);
@@ -231,7 +231,7 @@ contract Editable is  Accessible {
 
     function setGroupRights(address group, uint8 access_type, uint8 access) public {
         AccessIndexor indexor = AccessIndexor(group);
-        indexor.setRights(indexCategory, address(this), access_type, access);
+        indexor.setEntityRights(indexCategory, address(this), access_type, access);
     }
 
     function setVisibility(uint8 _visibility_code) public onlyEditor {


### PR DESCRIPTION
This should allow GO to compile properly.
Still we should investigate the root cause, and find out if BaseAccessWallet needs to be a container.