### PR TITLE
Fix library creation glitch (registration done into groups' index ins…

### DIFF
--- a/base_content_space.sol
+++ b/base_content_space.sol
@@ -313,11 +313,12 @@ BaseFactory20190801140700ML: Removed access group creation to its own factory
 BaseFactory20200203112400ML: Only records SEE rights in wallet upon creation, to avoid interference with transfer of ownership
 BaseFactory20200316120700ML: Uses content-type setRights instead of going straight to the wallet
 BaseFactory20200928110000PO: Replace tx.origin with msg.sender in some cases
+BaseFactory20201129223200ML: Fix glitch in creation of library (registration to the wrong index)
 */
 
 contract BaseTypeFactory is Ownable {
 
-    bytes32 public version ="BaseTypeFactory20200928110000PO"; //class name (max 16), date YYYYMMDD, time HHMMSS and Developer initials XX
+    bytes32 public version ="BaseFactory20201129223200ML"; //class name (max 16), date YYYYMMDD, time HHMMSS and Developer initials XX
 
     constructor(address payable _spaceAddr) public {
         contentSpace = _spaceAddr;
@@ -427,7 +428,7 @@ contract BaseLibraryFactory is Ownable {
         if (!isV3Contract) {
             AccessIndexor index = AccessIndexor(userWallet);
             theLib.transferOwnership(tx.origin);
-            index.setAccessGroupRights(newLib, 0, 2);
+            index.setLibraryRights(newLib, 0, 2);
         } else {
             // v3+ path ...
             theLib.setRights(tx.origin, 0 /*TYPE_SEE*/, 2 /*ACCESS_CONFIRMED*/);  // register library in user wallet

--- a/base_library.sol
+++ b/base_library.sol
@@ -22,12 +22,13 @@ BaseLibrary20200110162700ML: Adds support for visibility, differentiates rights 
 BaseLibrary20200211164300ML: Modified to conform to authV3 API
 BaseLibrary20200316135200ML: Leverages inherited hasAccess
 BaseLibrary20200928110000PO: Replace tx.origin with msg.sender in some cases
+BaseLibrary20201129223200ML: Bump up version to match update in the factory
 */
 
 
 contract BaseLibrary is MetaObject, Container {
 
-    bytes32 public version ="BaseLibrary20200928110000PO"; //class name (max 16), date YYYYMMDD, time HHMMSS and Developer initials XX
+    bytes32 public version = "BaseLibrary20201129223200ML"; //class name (max 16), date YYYYMMDD, time HHMMSS and Developer initials XX
 
     address payable[] public contributorGroups;
     address payable[] public reviewerGroups;


### PR DESCRIPTION
Upon creation, library were registered in the groups indexer instead of their own.
Only the factory code was modified to fix that glitch, but I also updated the version of the base_library class, so that we can tell whether a library is affected by the glitch or not